### PR TITLE
Modified syntax of logging methods according to those of Logger class

### DIFF
--- a/lib/syslog-logger.rb
+++ b/lib/syslog-logger.rb
@@ -52,13 +52,13 @@ class Logger::Syslog
   # Builds a methods for level +meth+.
   for severity in Logger::Severity.constants
     class_eval <<-EOT, __FILE__, __LINE__
-      def #{severity.downcase}(message = nil, progname = nil, &block)  # def debug(message = nil, progname = nil, &block)
-        add(#{severity}, message, progname, &block)                    #   add(DEBUG, message, progname, &block)
-      end                                                              # end
-                                                                       #
-      def #{severity.downcase}?                                        # def debug?
-        @level <= #{severity}                                          #   @level <= DEBUG
-      end                                                              # end
+      def #{severity.downcase}(progname = nil, &block)  # def debug(progname = nil, &block)
+        add(#{severity}, nil, progname, &block)         #   add(DEBUG, nil, progname, &block)
+      end                                               # end
+                                                        #
+      def #{severity.downcase}?                         # def debug?
+        @level <= #{severity}                           #   @level <= DEBUG
+      end                                               # end
     EOT
   end
 


### PR DESCRIPTION
Updated methods below so that

``` ruby
debug('progname'){ 'message' }
```

can generate a syslog like

```
Mar 24 17:21:09 my_mac rails[17421]: [17:21:09.650780 ] [DEBUG]: message
```

instead of

```
Mar 24 17:21:09 my_mac rails[17421]: [17:21:09.650780 ] [DEBUG]: progname
```
- unkown()
- fatal()
- error()
- warn()
- info()
- debug()

According to API (eg: http://www.ruby-doc.org/stdlib-1.9.3/libdoc/logger/rdoc/Logger.html#method-i-debug)

'debug' looks like:

``` ruby
def debug(progname = nil, &block)
  add(DEBUG, nil, progname, &block)
end
```

not

``` ruby
def debug(message = nil, progname = nil, &block)
  add(DEBUG, message, progname, &block)
end
```

My changes are tested with ruby 1.8.7-p358, 1.9.2-p318 and 1.9.3-p125.

thanks
