### PR TITLE
Rakefile: add license metadata

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,6 +22,7 @@ jt = Jeweler::Tasks.new do |gem|
   gem.has_rdoc = true
   gem.extra_rdoc_files = ["README.rdoc"]
   gem.rdoc_options = ["--line-numbers", "--inline-source", "--title", "SyslogLogger", "--main", "README.rdoc"]
+  gem.license = "MIT"
 end
 Jeweler::GemcutterTasks.new
 


### PR DESCRIPTION
so the data is visible on e.g. rubygems.org and can be used
by compliance tooling

Signed-off-by: Konrad Weihmann <kweihmann@outlook.com>